### PR TITLE
fix whiteout issue by removing <script> element in next page doc

### DIFF
--- a/src/autopagerize.user.js
+++ b/src/autopagerize.user.js
@@ -699,7 +699,8 @@ function loadWithXHR(url, callback, errback) {
     req.open('GET', url)
     req.responseType = 'document'
     req.addEventListener('load', function (event) {
-        callback(event.target.response, event.target.responseURL)
+        var doc = removeScripts(event.target.response)
+        callback(doc, event.target.responseURL)
     })
     req.addEventListener('error', errback)
     req.send()
@@ -718,12 +719,8 @@ function loadWithIframe(url, callback, errback) {
             }
             else {
                 var loadedURL = iframe.contentWindow ? iframe.contentWindow.location.href : null
-                var doc = iframe.contentDocument
-                var ss =  doc.querySelectorAll('script')
-                for (var i = 0; i < ss.length; i++) {
-                    ss[i].parentNode.removeChild(ss[i])
-                }
-                callback(iframe.contentDocument, loadedURL)
+                var doc = removeScripts(iframe.contentDocument)
+                callback(doc, loadedURL)
             }
             iframe.parentNode.removeChild(iframe)
         }
@@ -733,6 +730,14 @@ function loadWithIframe(url, callback, errback) {
     }
     iframe.onload = contentload
     iframe.onerror = errback
+}
+
+function removeScripts(doc) {
+    var ss =  doc.querySelectorAll('script')
+    for (var i = 0; i < ss.length; i++) {
+        ss[i].parentNode.removeChild(ss[i])
+    }
+    return doc
 }
 
 function createHTMLDocumentByString(str) {


### PR DESCRIPTION
`document.write()` の呼び出しを含む `<script>` 要素が pageElement に含まれている場合に、2ページ目を継ぎ足した直後にページ上のDOM要素がすべて消え、何も表示されなくなくなっています。
http://request-xkhorasan.rhcloud.com/ap/document-write に再現用のページを用意しました。

このpull requestでは、このような場合でもページを表示させるために、 iframeでの次ページ読み込みで実施している `<script>` の除去を、XHRのよる読み込みの場合も行うよう変更しています。
