### PR TITLE
Local custom rules

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -8,6 +8,9 @@
   "exclude_patterns" : {
     "message": "Exclude Patterns"
   },
+  "custom_rules" : {
+    "message": "Custom rules"
+  },
   "example" : {
     "message": "Example"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -8,6 +8,9 @@
   "exclude_patterns" : {
     "message": "除外パターン"
   },
+  "custom_rules" : {
+    "message": "追加の定義"
+  },
   "example" : {
     "message": "例"
   },

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -8,6 +8,9 @@
   "exclude_patterns" : {
     "message": "Отключить на следующих сайтах"
   },
+  "custom_rules" : {
+    "message": "Дополнительные правила"
+  },
   "example" : {
     "message": "Пример"
   },

--- a/src/options.css
+++ b/src/options.css
@@ -3,10 +3,11 @@ body {
   font-family: sans-serif;
   background-color: #eee;
   color: #444;
+  font-size: 12pt;
 }
 .desc {
   margin: 3px 0 10px 7px;
-  font-size: 90%;
+  font-size: 75%;
 }
 code {
   background-color: #fffff9;
@@ -21,11 +22,8 @@ textarea {
 .footer {
   position: fixed;
   bottom: 1em;
-  font-size: 80%;
+  font-size: 70%;
 }
 a, a:visited {
   color: #333;
-}
-.footer a {
-  font-size: 90%;
 }

--- a/src/options.html
+++ b/src/options.html
@@ -15,9 +15,38 @@
         </div>
         <br />
 
+        <div><label for="form_rules" class="i18n">custom_rules</label></div>
+        <div>
+          <textarea id="form_rules" rows="20" style="width:100%">
+[
+{
+    "url": "",
+    "nextLink": "",
+    "pageElement": ""
+}
+]
+          </textarea>
+        </div>
+
+        <div class="desc">
+          <pre>[
+{
+    "url": "^http://some\\.site/path/",
+    "nextLink": "//a[@rel='next']",
+    "pageElement": "id('main')"
+},
+{
+    "url": "^http://some\\.site/path/",
+    "nextLink": "//span[contains(@class,'someclass')]/following-sibling::a[1]",
+    "pageElement": "id('main')",
+    "insertBefore": "id(\"xcolumn1\")//div[@class=\"prevnext\"]"
+}
+]</pre>
+        </div>
+
         <div><label for="form_ep" class="i18n">exclude_patterns</label></div>
         <div>
-          <textarea id="form_ep" cols="60" rows="7"></textarea>
+          <textarea id="form_ep" rows="7" style="width:100%"></textarea>
         </div>
 
         <div class="desc">

--- a/src/options.js
+++ b/src/options.js
@@ -7,15 +7,27 @@ function init() {
 
     var settings = JSON.parse(localStorage['settings'])
     var form = document.getElementById('settings_form')
+    var form_rules = document.getElementById('form_rules')
     var form_ep = document.getElementById('form_ep')
     var form_dm = document.getElementById('form_dm')
+    if (settings['custom_rules']) {
+    	form_rules.value = settings['custom_rules'];
+    }
     form_ep.value = settings['exclude_patterns'] || ''
     form_dm.checked = settings['display_message_bar'] === false ? false : 'checked'
     form.addEventListener('submit', function() {
+        var rules_changed = settings['custom_rules'] != form_rules.value;
+        settings['custom_rules'] = form_rules.value.trim()
         settings['exclude_patterns'] = form_ep.value
         settings['display_message_bar'] = !!form_dm.checked
         localStorage['settings'] = JSON.stringify(settings)
         dispatchMessageAll('updateSettings', settings)
+        if (rules_changed) {
+            chrome.runtime.sendMessage( { name: 'update_customrules' }, function(res) {
+                if (res.error)
+                    alert(chrome.i18n.getMessage("custom_rules") + "\n\n" + res.error);
+            })
+        }
     }, false)
     updateCacheInfoInfo()
 


### PR DESCRIPTION
Custom rules textbox in Options provides an ability to quickly test the rules before submitting to wedata sitedb.
Closes #7.

``` js
[
{
    "url": "^http:\/\/some\\.site\/path\/",
    "pageElement": "body>table:not(:first)",
    "nextLink": "div.n td:last a"
},
{
    "url": "^http:\/\/some\\.site\/path\/",
    "pageElement": "\/\/id('main')",
    "nextLink": "\/\/span[contains(@class,'someclass')]\/following-sibling::a[1]",
    "insertBefore": "id(\"xcolumn1\")\/\/div[@class=\"prevnext\"]"
}
]
```

My implementation is most probably not the best but it works at least.
